### PR TITLE
URL Cleanup

### DIFF
--- a/correlator.go
+++ b/correlator.go
@@ -103,7 +103,7 @@ func parsePathToChannel(path string) (namespace, channel string) {
 
 func sendToChannel(namespace, channel string, correlationID string, r *http.Request) error {
 	fmt.Printf("SENDING TO %s/%s\n", namespace, channel)
-	url := fmt.Sprintf("http://%s-channel.%s.svc.cluster.local", channel, namespace)
+	url := fmt.Sprintf("https://%s-channel.%s.svc.cluster.local", channel, namespace)
 	req, err := http.NewRequest(http.MethodPost, url, r.Body)
 	if err != nil {
 		return err

--- a/vendor/github.com/google/uuid/README.md
+++ b/vendor/github.com/google/uuid/README.md
@@ -4,7 +4,7 @@ The API will become stable with v1.
 
 # uuid ![build status](https://travis-ci.org/google/uuid.svg?branch=master)
 The uuid package generates and inspects UUIDs based on
-[RFC 4122](http://tools.ietf.org/html/rfc4122)
+[RFC 4122](https://tools.ietf.org/html/rfc4122)
 and DCE 1.1: Authentication and Security Services. 
 
 This package is based on the github.com/pborman/uuid package (previously named
@@ -16,8 +16,8 @@ change is the ability to represent an invalid UUID (vs a NIL UUID).
 `go get github.com/google/uuid`
 
 ###### Documentation 
-[![GoDoc](https://godoc.org/github.com/google/uuid?status.svg)](http://godoc.org/github.com/google/uuid)
+[![GoDoc](https://godoc.org/github.com/google/uuid?status.svg)](https://godoc.org/github.com/google/uuid)
 
 Full `go doc` style documentation for the package can be viewed online without
 installing this package by using the GoDoc site here: 
-http://godoc.org/github.com/google/uuid
+https://godoc.org/github.com/google/uuid


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://%s-channel.%s.svc.cluster.local (UnknownHostException) with 1 occurrences migrated to:  
  https://%s-channel.%s.svc.cluster.local ([https](https://%s-channel.%s.svc.cluster.local) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://godoc.org/github.com/google/uuid with 2 occurrences migrated to:  
  https://godoc.org/github.com/google/uuid ([https](https://godoc.org/github.com/google/uuid) result 200).
* http://tools.ietf.org/html/rfc4122 with 1 occurrences migrated to:  
  https://tools.ietf.org/html/rfc4122 ([https](https://tools.ietf.org/html/rfc4122) result 200).